### PR TITLE
Feature/filter top domains

### DIFF
--- a/piholelongtermstats/app.py
+++ b/piholelongtermstats/app.py
@@ -23,6 +23,8 @@ from piholelongtermstats.plot import (
     generate_plot_data,
     generate_client_activity_over_time,
     generate_queries_over_time,
+    generate_top_blocked_domains,
+    generate_top_allowed_domains,
 )
 
 __version__ = "0.2.4"
@@ -189,6 +191,10 @@ def serve_layout(
     callback_data = {
         "hourly_agg": hourly_data["hourly_agg"],
         "top_clients": hourly_data["top_clients"],
+        "blocked_df": plot_data["blocked_df"],
+        "allowed_df": plot_data["allowed_df"],
+        "blocked_df_by_client": plot_data["blocked_df_by_client"],
+        "allowed_df_by_client": plot_data["allowed_df_by_client"],
         "data_span_days": plot_data["data_span_days"],
     }
 
@@ -707,8 +713,6 @@ def serve_layout(
             html.Br(),
             html.Div(
                 [
-                    html.H2("Queries over time"),
-                    html.H5("Queries from all clients. The data is aggregated hourly."),
                     dcc.Dropdown(
                         options=[
                             {"label": c, "value": c} for c in plot_data["client_list"]
@@ -716,6 +720,8 @@ def serve_layout(
                         id="client-filter",
                         placeholder="Select a Client",
                     ),
+                    html.H2("Queries over time"),
+                    html.H5("Queries from all clients. The data is aggregated hourly."),
                     dcc.Graph(id="filtered-view", figure=initial_filtered_fig),
                     html.H2("Client Activity Over Time"),
                     html.H5(
@@ -1134,6 +1140,31 @@ def update_client_activity(client, n_clicks):
     )
 
     return fig
+
+
+@app.callback(
+    Output("top-blocked-domains", "figure"),
+    Output("top-allowed-domains", "figure"),
+    Input("client-filter", "value"),
+    Input("reload-button", "n_clicks"),
+    prevent_initial_call=True,
+)
+def update_top_domains(client, n_clicks):
+    logging.info("Updating top blocked and allowed domain plots...")
+    global PHLTS_CALLBACK_DATA
+
+    blocked_fig = generate_top_blocked_domains(
+        callback_data=PHLTS_CALLBACK_DATA,
+        n_domains=args.n_domains,
+        client=client,
+    )
+    allowed_fig = generate_top_allowed_domains(
+        callback_data=PHLTS_CALLBACK_DATA,
+        n_domains=args.n_domains,
+        client=client,
+    )
+
+    return blocked_fig, allowed_fig
 
 
 def run():

--- a/piholelongtermstats/plot.py
+++ b/piholelongtermstats/plot.py
@@ -8,7 +8,6 @@ import gc
 import plotly.express as px
 import itertools
 
-
 def generate_plot_data(df, n_clients, n_domains):
     """Generate plot data for dashboard visualizations.
     
@@ -70,6 +69,22 @@ def generate_plot_data(df, n_clients, n_domains):
         .reset_index()
         .rename(columns={"domain": "Domain", "count": "count"})
     )
+
+    blocked_df_by_client = (
+        tmp_blocked.groupby(["client", "domain"]).size().reset_index(name="count")
+    )
+    blocked_df_by_client["Domain"] = blocked_df_by_client["domain"].apply(shorten)
+    blocked_df_by_client = blocked_df_by_client[
+        ["client", "Domain", "count"]
+    ].sort_values(["client", "count"], ascending=[True, False])
+
+    allowed_df_by_client = (
+        tmp_allowed.groupby(["client", "domain"]).size().reset_index(name="count")
+    )
+    allowed_df_by_client["Domain"] = allowed_df_by_client["domain"].apply(shorten)
+    allowed_df_by_client = allowed_df_by_client[
+        ["client", "Domain", "count"]
+    ].sort_values(["client", "count"], ascending=[True, False])
 
     logging.info("Generated plot data for allowed and blocked domains.")
 
@@ -152,6 +167,8 @@ def generate_plot_data(df, n_clients, n_domains):
         "top_clients_stacked": top_clients_stacked,
         "blocked_df": blocked_df,
         "allowed_df": allowed_df,
+        "blocked_df_by_client": blocked_df_by_client,
+        "allowed_df_by_client": allowed_df_by_client,
         "reply_time_df": reply_time_df,
         "client_list": client_list,
         "data_span_days": data_span_days,
@@ -361,4 +378,65 @@ def generate_client_activity_over_time(callback_data, n_clients, client=None):
     del dff_grouped, pivot_df
     gc.collect()
 
+    return fig
+
+def generate_top_blocked_domains(callback_data, n_domains, client=None):
+    logging.info("Generating top blocked domains plot...")
+    if client is not None:
+        dff = callback_data.get("blocked_df_by_client", pd.DataFrame()).copy()
+        dff = dff[dff["client"] == client]
+        dff = dff.nlargest(n_domains, "count").reset_index(drop=True)
+        title_txt = f"Domains for {client}"
+    else:
+        dff = callback_data.get("blocked_df", pd.DataFrame()).copy()
+        title_txt = ""
+
+    return _build_top_domain_figure(dff, title_txt, "#ef4444")
+
+
+def generate_top_allowed_domains(callback_data, n_domains, client=None):
+    logging.info("Generating top allowed domains plot...")
+    if client is not None:
+        dff = callback_data.get("allowed_df_by_client", pd.DataFrame()).copy()
+        dff = dff[dff["client"] == client]
+        dff = dff.nlargest(n_domains, "count").reset_index(drop=True)
+        title_txt = f"Domains for {client}"
+    else:
+        dff = callback_data.get("allowed_df", pd.DataFrame()).copy()
+        title_txt = ""
+
+    return _build_top_domain_figure(dff, title_txt, "#10b981")
+
+def _build_top_domain_figure(domain_df, title_txt, color):
+    if domain_df is None or domain_df.empty:
+        fig = px.bar(
+            pd.DataFrame({"Domain": [], "count": []}),
+            x="Domain",
+            y="count",
+            template="plotly_white",
+        )
+        fig.update_layout(
+            title=title_txt,
+            title_font_size=16,
+            showlegend=False,
+            margin=dict(r=0, t=50, l=0, b=0),
+            xaxis=dict(title=None, automargin=True, tickmode="auto"),
+        )
+        return fig
+
+    fig = px.bar(
+        domain_df,
+        y="count",
+        x="Domain",
+        labels={"Domain": "Domain", "count": "Count"},
+        template="plotly_white",
+        color_discrete_sequence=[color],
+    )
+    fig.update_layout(
+        title=title_txt,
+        title_font_size=16,
+        showlegend=False,
+        margin=dict(r=0, t=50, l=0, b=0),
+        xaxis=dict(title=None, automargin=True, tickmode="auto"),
+    )
     return fig

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -5,6 +5,8 @@ from piholelongtermstats.plot import (
     generate_plot_data,
     generate_queries_over_time,
     generate_client_activity_over_time,
+    generate_top_blocked_domains,
+    generate_top_allowed_domains,
 )
 from piholelongtermstats.process import prepare_hourly_aggregated_data
 
@@ -32,6 +34,8 @@ class TestGeneratePlotData:
             "top_clients_stacked",
             "blocked_df",
             "allowed_df",
+            "blocked_df_by_client",
+            "allowed_df_by_client",
             "reply_time_df",
             "client_list",
             "data_span_days",
@@ -80,6 +84,44 @@ class TestGeneratePlotData:
         
         assert len(blocked_df) <= n_domains
         assert len(allowed_df) <= n_domains
+
+        blocked_df_by_client = result["blocked_df_by_client"]
+        allowed_df_by_client = result["allowed_df_by_client"]
+
+        assert isinstance(blocked_df_by_client, pd.DataFrame)
+        assert isinstance(allowed_df_by_client, pd.DataFrame)
+        assert "client" in blocked_df_by_client.columns
+        assert "client" in allowed_df_by_client.columns
+
+    def test_generate_top_blocked_domains_function(self, plot_dataframe):
+        n_clients = 5
+        n_domains = 10
+        result = generate_plot_data(plot_dataframe, n_clients, n_domains)
+        callback_data = result
+
+        fig = generate_top_blocked_domains(callback_data, n_domains=n_domains)
+        assert isinstance(fig, go.Figure)
+        assert "Top" in fig.layout.title.text
+
+        client = plot_dataframe["client"].iloc[0]
+        fig_client = generate_top_blocked_domains(callback_data, n_domains=n_domains, client=client)
+        assert isinstance(fig_client, go.Figure)
+        assert client in fig_client.layout.title.text
+
+    def test_generate_top_allowed_domains_function(self, plot_dataframe):
+        n_clients = 5
+        n_domains = 10
+        result = generate_plot_data(plot_dataframe, n_clients, n_domains)
+        callback_data = result
+
+        fig = generate_top_allowed_domains(callback_data, n_domains=n_domains)
+        assert isinstance(fig, go.Figure)
+        assert "Top" in fig.layout.title.text
+
+        client = plot_dataframe["client"].iloc[0]
+        fig_client = generate_top_allowed_domains(callback_data, n_domains=n_domains, client=client)
+        assert isinstance(fig_client, go.Figure)
+        assert client in fig_client.layout.title.text
 
     def test_generate_plot_data_reply_time_df(self, plot_dataframe):
         """Test reply time dataframe."""

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -101,7 +101,6 @@ class TestGeneratePlotData:
 
         fig = generate_top_blocked_domains(callback_data, n_domains=n_domains)
         assert isinstance(fig, go.Figure)
-        assert "Top" in fig.layout.title.text
 
         client = plot_dataframe["client"].iloc[0]
         fig_client = generate_top_blocked_domains(callback_data, n_domains=n_domains, client=client)
@@ -116,7 +115,6 @@ class TestGeneratePlotData:
 
         fig = generate_top_allowed_domains(callback_data, n_domains=n_domains)
         assert isinstance(fig, go.Figure)
-        assert "Top" in fig.layout.title.text
 
         client = plot_dataframe["client"].iloc[0]
         fig_client = generate_top_allowed_domains(callback_data, n_domains=n_domains, client=client)


### PR DESCRIPTION
* Added support for displaying the top blocked and top allowed domains, both globally and per‑client.
* Filtering can be though previous client-filter dropdown.
* Added generate_top_blocked_domains and generate_top_allowed_domains in piholelongtermstats/plot.py.
