### PR TITLE
Feature/friendly names

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,34 +86,38 @@ If you have a copy of your `pihole-FTL.db` file, you can quickly run the dashboa
     
     ```docker
     services:
-      pihole-long-term-stats:
+    pihole-long-term-stats:
         image: ghcr.io/davistdaniel/piholelongtermstats:latest
         container_name: pihole-lt-stats
         ports:
-          - "9292:9292"  # Map host port to container port
+        - "9292:9292"  # Map host port to container port
         volumes:
-          - ./pihole-FTL.db:/app/pihole-FTL.db:ro  # Path to your Pi-hole DB file (adjust if it's not in current directory)
-          # To include additional Pi-hole databases, mount each one similarly:
-          #- ./pihole-FTL-2.db:/app/pihole-FTL-2.db:ro
+        - ./pihole-FTL.db:/app/pihole-FTL.db:ro  # Path to your Pi-hole DB file (adjust if it's not in current directory)
+        # To include additional Pi-hole databases, mount each one similarly, then also specify in environment :
+        #- ./pihole-FTL-2.db:/app/pihole-FTL-2.db:ro
         environment:
-          - PIHOLE_LT_STATS_DB_PATH=/app/pihole-FTL.db  # Path inside the container to the mounted DB file
-          
-          # Provide multiple databases by listing their container paths as a
-          # comma-separated string, e.g.:
-          #- PIHOLE_LT_STATS_DB_PATH=/app/pihole-FTL.db,/app/pihole-FTL-2.db
 
-          - PIHOLE_LT_STATS_DAYS=31                     # Number of days from now of data to analyze; change if desired
-          - PIHOLE_LT_STATS_PORT=9292                   # Port the app listens to inside container; keep in sync with ports mapping
-          - PIHOLE_LT_STATS_NCLIENTS=10                 # Number of clients to show in top clients plots
-          - PIHOLE_LT_STATS_NDOMAINS=10                 # Number of domains to show in top domains plots
-          - PIHOLE_LT_STATS_TIMEZONE=UTC                # timezone for display
-          #- PIHOLE_LT_STATS_IGNORE_DOMAINS=.*\.local   # regex patterns for excluding domains. Example: to exclude all .local domains use .*\.local
-          
-          # To ignore multiple domain patterns, separate each regex with a comma.
-          # example definition below ignores: anything ending in .local, anything starting with ads, exactly example.com
-          #- PIHOLE_LT_STATS_IGNORE_DOMAINS=.*\.local,^ads\.,^example\.com$
+        # Configuration guide can be found on the github repository.
+
+        - PIHOLE_LT_STATS_DB_PATH=/app/pihole-FTL.db  # Path inside the container to the mounted DB file
+        - PIHOLE_LT_STATS_DAYS=31                     # Number of days from now of data to analyze; change if desired
+        - PIHOLE_LT_STATS_PORT=9292                   # Port the app listens to inside container; keep in sync with ports mapping
+        - PIHOLE_LT_STATS_NCLIENTS=10                 # Number of clients to show in top clients plots
+        - PIHOLE_LT_STATS_NDOMAINS=10                 # Number of domains to show in top domains plots
+        - PIHOLE_LT_STATS_TIMEZONE=UTC                # timezone for display
+        - PIHOLE_LT_STATS_CLIENT_ID=hostname          # Client grouping and display criterion
+        #- PIHOLE_LT_STATS_IGNORE_DOMAINS=.*\.local   # regex patterns for excluding domains. Example: to exclude all .local domains use .*\.local 
+
+        # Provide multiple databases by listing their container paths as a
+        # comma-separated string, e.g.:
+        #- PIHOLE_LT_STATS_DB_PATH=/app/pihole-FTL.db,/app/pihole-FTL-2.db
+
+        # To ignore multiple domain patterns, separate each regex with a comma.
+        # example definition below ignores: anything ending in .local, anything starting with ads, exactly example.com
+        #- PIHOLE_LT_STATS_IGNORE_DOMAINS=.*\.local,^ads\.,^example\.com$
 
         restart: unless-stopped
+
     ```
     and run using :
 
@@ -244,7 +248,7 @@ If installing using python, you can install from this git repo or as a package f
 
 ## ⚙️ Configuration
 
-You can configure the application using command-line arguments or environment variables:
+You can configure the application using command-line arguments or environment variables. For a detailed reference on all settings and configurations, see the [Configuration Guide](docs/configuration_guide.md).
 
 | Command-Line Argument | Environment Variable         | Default Value   | Description                                      |
 |-----------------------|------------------------------|-----------------|--------------------------------------------------|
@@ -252,13 +256,15 @@ You can configure the application using command-line arguments or environment va
 | `--days`         | `PIHOLE_LT_STATS_DAYS`       | `31`           | Number of days back from today to analyze.          |
 | `--port`         | `PIHOLE_LT_STATS_PORT`       | `9292`          | Port number to serve the Dash app on.            |
 | `--n_clients`         | `PIHOLE_LT_STATS_NCLIENTS`       | `10`          | Number of top clients to show in top clients plots.            |
-| `--n_domains`         | `PIHOLE_LT_STATS_NDOMAINS`       | `10`          | Number of top clients to show in top clients plots.            |
-| `--port`         | `PIHOLE_LT_STATS_TIMEZONE`       | `UTC`          | Timezone for displaying times in the dashboard.            |
-| `--ignore-domains` | `PIHOLE_LT_STATS_IGNORE_DOMAINS` | `""` | Comma-separated regex patterns to exclude domains from from stats (e.g to exlcude all .local domains, use ".*\.local") |
+| `--n_domains`         | `PIHOLE_LT_STATS_NDOMAINS`       | `10`          | Number of top domains to show in top domains plots.            |
+| `--timezone`         | `PIHOLE_LT_STATS_TIMEZONE`       | `UTC`          | Timezone for displaying times in the dashboard.            |
+| `--ignore-domains` | `PIHOLE_LT_STATS_IGNORE_DOMAINS` | `""` | Comma-separated regex patterns to exclude domains from stats (e.g. to exclude all `.local` domains, use `.*\.local`). |
+| `--client_id`      | `PIHOLE_LT_STATS_CLIENT_ID`      | `hostname`      | Client grouping criterion (e.g., `hostname`, `mac`, `ip`, `hostname_mac`, `hostname_ip`, `mac_ip`). |
+
 
 ## 🧑‍💻 Contributing
 
-Any contribution, feature ideas or bug fixes are always welcome.
+Any contribution, feature ideas, documentation improvements or bug fixes are always welcome.
 In case of new features, opening an issue and discussion before implementation is recommended.
 This project uses uv for dependency management.
 

--- a/README.md
+++ b/README.md
@@ -289,10 +289,6 @@ This project uses uv for dependency management.
 * Make your changes.
 * Submit a pull request.
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=davistdaniel/PiHoleLongTermStats&type=date&legend=top-left)](https://www.star-history.com/#davistdaniel/PiHoleLongTermStats&type=date&legend=top-left)
-
 ## Supported metrics
 | Metric | Description |
 |--------|-------------|

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pi Hole Long Term Statistics v.0.2.6
+# Pi Hole Long Term Statistics v.0.2.7
 
 <div align="center">
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,22 +6,25 @@ services:
       - "9292:9292"  # Map host port to container port
     volumes:
       - ./pihole-FTL.db:/app/pihole-FTL.db:ro  # Path to your Pi-hole DB file (adjust if it's not in current directory)
-      # To include additional Pi-hole databases, mount each one similarly:
+      # To include additional Pi-hole databases, mount each one similarly, then also specify in environment :
       #- ./pihole-FTL-2.db:/app/pihole-FTL-2.db:ro
     environment:
-      - PIHOLE_LT_STATS_DB_PATH=/app/pihole-FTL.db  # Path inside the container to the mounted DB file
-      
-      # Provide multiple databases by listing their container paths as a
-      # comma-separated string, e.g.:
-      #- PIHOLE_LT_STATS_DB_PATH=/app/pihole-FTL.db,/app/pihole-FTL-2.db
 
+      # Configuration guide can be found on the github repository.
+
+      - PIHOLE_LT_STATS_DB_PATH=/app/pihole-FTL.db  # Path inside the container to the mounted DB file
       - PIHOLE_LT_STATS_DAYS=31                     # Number of days from now of data to analyze; change if desired
       - PIHOLE_LT_STATS_PORT=9292                   # Port the app listens to inside container; keep in sync with ports mapping
       - PIHOLE_LT_STATS_NCLIENTS=10                 # Number of clients to show in top clients plots
       - PIHOLE_LT_STATS_NDOMAINS=10                 # Number of domains to show in top domains plots
       - PIHOLE_LT_STATS_TIMEZONE=UTC                # timezone for display
-      #- PIHOLE_LT_STATS_IGNORE_DOMAINS=.*\.local   # regex patterns for excluding domains. Example: to exclude all .local domains use .*\.local
-      
+      - PIHOLE_LT_STATS_CLIENT_ID=hostname          # Client grouping and display criterion
+      #- PIHOLE_LT_STATS_IGNORE_DOMAINS=.*\.local   # regex patterns for excluding domains. Example: to exclude all .local domains use .*\.local 
+
+      # Provide multiple databases by listing their container paths as a
+      # comma-separated string, e.g.:
+      #- PIHOLE_LT_STATS_DB_PATH=/app/pihole-FTL.db,/app/pihole-FTL-2.db
+
       # To ignore multiple domain patterns, separate each regex with a comma.
       # example definition below ignores: anything ending in .local, anything starting with ads, exactly example.com
       #- PIHOLE_LT_STATS_IGNORE_DOMAINS=.*\.local,^ads\.,^example\.com$

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -1,0 +1,164 @@
+# Configuration Guide
+
+This guide is for configuring **PiHoleLongTermStats** using environment variables (ideal for Docker Compose) or command-line arguments (ideal for direct Python execution).
+
+## Configuration Options
+
+| Command-Line Argument | Environment Variable | Default Value | Description |
+| :--- | :--- | :--- | :--- |
+| `--db_path` | `PIHOLE_LT_STATS_DB_PATH` | `pihole-FTL.db` | Path to the copy of the Pi-hole database file. To consolidate multiple databases, specify paths as comma-separated values. |
+| `--days` | `PIHOLE_LT_STATS_DAYS` | `31` | Number of days of historical data to load relative to today. |
+| `--port` | `PIHOLE_LT_STATS_PORT` | `9292` | Network port for the Dash server. |
+| `--n_clients` | `PIHOLE_LT_STATS_NCLIENTS` | `10` | Maximum number of top clients to display in top clients plots. |
+| `--n_domains` | `PIHOLE_LT_STATS_NDOMAINS` | `10` | Maximum number of top domains to display in top domains plots. |
+| `--timezone` | `PIHOLE_LT_STATS_TIMEZONE` | `UTC` | Timezone database string (e.g., `Europe/Berlin`, `America/New_York`) to map and display query times. |
+| `--ignore-domains` | `PIHOLE_LT_STATS_IGNORE_DOMAINS` | `""` | Comma-separated list of regex patterns for excluding domains from statistic counts (e.g., `.*\.local,^ads\.`). |
+| `--client_id` | `PIHOLE_LT_STATS_CLIENT_ID` | `hostname` | Method used to identify, group, and format clients. Supported modes: `hostname`, `mac`, `hostname_mac`, `ip`, `hostname_ip`, `mac_ip`. |
+
+---
+
+## Configuration Details
+
+### Database Path (`--db_path` / `PIHOLE_LT_STATS_DB_PATH`)
+Specifies the path to the `pihole-FTL.db` database. 
+
+Multiple databases can be consolidated using a comma-separated list:
+```bash
+# Python
+piholelongtermstats --db_path "pihole-FTL.db,pihole-FTL-2.db"
+
+```
+
+```yaml
+# Docker environment
+    volumes:
+      - ./pihole-FTL.db:/app/pihole-FTL.db:ro
+      - ./pihole-FTL-2.db:/app/pihole-FTL-2.db:ro
+    environment:
+      PIHOLE_LT_STATS_DB_PATH=/app/pihole-FTL.db,/app/pihole-FTL-2.db
+
+```
+
+### Days (`--days` / `PIHOLE_LT_STATS_DAYS`)
+
+Number of days of historical data to load relative to today.
+
+If you get empty database errors, try increasing days to include older data. Verify that the timezone is set correctly. Note that increasing this value leads to higher memory consumption during application startup since a larger time range must be processed.
+
+```bash
+# Python
+piholelongtermstats --days 91
+
+```
+
+```yaml
+# Docker environment
+    environment:
+      PIHOLE_LT_STATS_DAYS=91
+
+```
+
+### Port (`--port` / `PIHOLE_LT_STATS_PORT`)
+
+Specifies the network port on which the Dash web application will listen.
+
+```bash
+# Python
+piholelongtermstats --port 9292
+
+```
+
+```yaml
+# Docker environment
+    ports:
+      - "9292:9292"
+    environment:
+      PIHOLE_LT_STATS_PORT=9292
+
+```
+
+### Top Items Limit (`--n_clients`, `--n_domains` / `PIHOLE_LT_STATS_NCLIENTS`, `PIHOLE_LT_STATS_NDOMAINS`)
+
+Controls the maximum number of items featured in the top rankings plots (e.g., top domains or top clients).
+
+```bash
+# Python
+piholelongtermstats --n_clients 15 --n_domains 20
+
+```
+
+```yaml
+# Docker environment
+    environment:
+      PIHOLE_LT_STATS_NCLIENTS=15
+      PIHOLE_LT_STATS_NDOMAINS=20
+
+```
+
+### Timezone (`--timezone` / `PIHOLE_LT_STATS_TIMEZONE`)
+
+Sets the timezone used to parse database timestamps and display time-series graphs. Uses standard IANA timezone database strings (e.g., `Europe/Berlin`, `America/New_York`, `UTC`).
+
+```bash
+# Python
+piholelongtermstats --timezone "Europe/Berlin"
+
+```
+
+```yaml
+# Docker environment
+    environment:
+      PIHOLE_LT_STATS_TIMEZONE=Europe/Berlin
+
+```
+
+### Client ID Resolution Mode (`--client_id` / `PIHOLE_LT_STATS_CLIENT_ID`)
+
+Deafult is `hostname`. Determines how client endpoints are identified, grouped, and displayed across graphs and tables:
+
+* `hostname`: Uses the device name if mapped in Pi-hole; falls back to IP address.
+* `mac`: Uses the hardware MAC address of the device; falls back to IP address.
+* `hostname_mac`: Displayed as `hostname (mac)`.
+* `ip`: Standard IPv4 or IPv6 address.
+* `hostname_ip`: Displayed as `hostname (ip)`.
+* `mac_ip`: Displayed as `mac (ip)`.
+
+##### Notes
+
+- For accuracy in stats, it is best to use `mac` but for readability, this is not optimal. 
+- A better balance of accuracy and readability is using `hostname`. 
+- Using `ip` may lead to inaccurate stats, since devices may not have static IP adresses. -
+- `ip` is used as fallback if hostnames or mac aren't available.
+- Long hostnames could lead to plot labels taking up extra vertical space, overlapping, or getting truncated on the dashboard charts.
+
+```bash
+# Python
+piholelongtermstats --client_id "ip"
+
+```
+
+```yaml
+# Docker environment
+    environment:
+      PIHOLE_LT_STATS_CLIENT_ID=ip
+
+```
+
+### Ignoring Domains (`--ignore-domains` / `PIHOLE_LT_STATS_IGNORE_DOMAINS`)
+
+Allows filtering out noisy background domains using regular expressions. Multiple regex patterns can be separated by commas:
+
+```bash
+# Ignore local domains and any domains starting with "ads."
+piholelongtermstats --ignore-domains ".*\.local,^ads\."
+
+```
+
+```yaml
+# Docker environment
+    environment:
+      PIHOLE_LT_STATS_IGNORE_DOMAINS=.*\.local,^ads\.
+
+```
+
+---

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -127,7 +127,7 @@ Deafult is `hostname`. Determines how client endpoints are identified, grouped, 
 
 - For accuracy in stats, it is best to use `mac` but for readability, this is not optimal. 
 - A better balance of accuracy and readability is using `hostname`. 
-- Using `ip` may lead to inaccurate stats, since devices may not have static IP adresses. -
+- Using `ip` may lead to inaccurate stats, since devices may not have static IP adresses.
 - `ip` is used as fallback if hostnames or mac aren't available.
 - Long hostnames could lead to plot labels taking up extra vertical space, overlapping, or getting truncated on the dashboard charts.
 

--- a/piholelongtermstats/__init__.py
+++ b/piholelongtermstats/__init__.py
@@ -1,3 +1,3 @@
 ## Author :  Davis T. Daniel
-## PiHoleLongTermStats v.0.2.5
+## PiHoleLongTermStats v.0.2.7
 ## License :  MIT

--- a/piholelongtermstats/app.py
+++ b/piholelongtermstats/app.py
@@ -1,5 +1,5 @@
 ## Author :  Davis T. Daniel
-## PiHoleLongTermStats v.0.2.6
+## PiHoleLongTermStats v.0.2.7
 ## License :  MIT
 
 
@@ -29,7 +29,7 @@ from piholelongtermstats.plot import (
     generate_top_allowed_domains,
 )
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 
 # logging setup
 logging.basicConfig(

--- a/piholelongtermstats/app.py
+++ b/piholelongtermstats/app.py
@@ -1063,7 +1063,7 @@ def serve_layout(
                     html.Div(
                         [
                             html.H2("Reply Time Distribution"),
-                            html.H5("Distribution of reply times in milliseconds."),
+                            html.H5("Distribution of daily average reply times in milliseconds."),
                             dcc.Graph(
                                 id="reply-time-histogram",
                                 figure=px.histogram(

--- a/piholelongtermstats/app.py
+++ b/piholelongtermstats/app.py
@@ -91,6 +91,20 @@ parser.add_argument(
     help="Comma-separated list of domains or regex patterns to ignore. Default: no domains ignored. Env: PIHOLE_LT_STATS_IGNORE_DOMAINS",
 )
 
+parser.add_argument(
+    "--client_id",
+    choices=[
+        "hostname",
+        "mac",
+        "hostname_mac",
+        "ip",
+        "hostname_ip",
+        "mac_ip",
+    ],
+    default=os.getenv("PIHOLE_LT_STATS_CLIENT_ID", "hostname"),
+    help="Criterion for client resolution/identification, stats are calculated based on this grouping criterion. Falls back to IP if hostnames aren't available.",
+)
+
 args = parser.parse_args()
 
 logging.info("Setting environment variables:")
@@ -101,6 +115,7 @@ logging.info(f"PIHOLE_LT_STATS_NCLIENTS : {args.n_clients}")
 logging.info(f"PIHOLE_LT_STATS_NDOMAINS : {args.n_domains}")
 logging.info(f"PIHOLE_LT_STATS_TIMEZONE : {args.timezone}")
 logging.info(f"PIHOLE_LT_STATS_IGNORE_DOMAINS : {args.ignore_domains}")
+logging.info(f"PIHOLE_LT_STATS_CLIENT_ID : {args.client_id}")
 logging.info("Initializing PiHoleLongTermStats Dashboard")
 
 
@@ -115,6 +130,7 @@ def serve_layout(
     end_date=None,
     timezone="UTC",
     ignore_domains="",
+    client_id="hostname",
 ):
     """Read pihole ftl db, process data, compute stats"""
 
@@ -153,6 +169,7 @@ def serve_layout(
             start_date=start_date,
             end_date=end_date,
             timezone=timezone,
+            client_id=client_id
         ),
         ignore_index=True,
     )
@@ -647,8 +664,8 @@ def serve_layout(
                                 [
                                     html.H3("Longest Idle Period"),
                                     html.P(
-                                        f"{stats['max_idle_ms']:,.0f} s"
-                                        if stats["max_idle_ms"] is not None
+                                        f"{stats['max_idle_s']:,.0f} s"
+                                        if stats["max_idle_s"] is not None
                                         else "N/A"
                                     ),
                                     html.P(
@@ -709,7 +726,7 @@ def serve_layout(
                                         else "N/A"
                                     ),
                                     html.P(
-                                        "Average interval between successful queries.",
+                                        "Average interval between allowed queries.",
                                         style={"fontSize": "14px", "color": "#777"},
                                     ),
                                 ],
@@ -872,9 +889,9 @@ def serve_layout(
                             legend=dict(
                                 orientation="h",
                                 yanchor="top",
-                                y=-0.4,
+                                y=0.9,
                                 xanchor="center",
-                                x=0.5,
+                                x=0.9,
                             ),
                             xaxis=dict(title=None, automargin=True),
                         ),
@@ -1125,6 +1142,7 @@ PHLTS_CALLBACK_DATA, initial_layout = serve_layout(
     end_date=None,
     timezone=args.timezone,
     ignore_domains=args.ignore_domains,
+    client_id=args.client_id,
 )
 
 logging.info("Setting initial layout...")
@@ -1211,6 +1229,7 @@ def reload_page(n_clicks, start_date, end_date):
         end_date=end_date,
         timezone=args.timezone,
         ignore_domains=args.ignore_domains,
+        client_id=args.client_id,
     )
 
     # Persist the new layout so that a full browser refresh (which calls

--- a/piholelongtermstats/db.py
+++ b/piholelongtermstats/db.py
@@ -1,5 +1,5 @@
 ## Author :  Davis T. Daniel
-## PiHoleLongTermStats v.0.2.6
+## PiHoleLongTermStats v.0.2.7
 ## License :  MIT
 
 import sqlite3
@@ -151,8 +151,8 @@ def resolve_clients(df, hostname_map, mac_map, client_id="hostname"):
     """
 
     df["client_ip"] = df["client"]
-    df["client_mac"] = df["client_ip"].map(mac_map)
-    hostname = df["client_ip"].map(hostname_map)
+    df["client_mac"] = df["client_ip"].map(mac_map).astype(object)
+    hostname = df["client_ip"].map(hostname_map).astype(object)
 
     if client_id == "ip":
         resolved = df["client_ip"]

--- a/piholelongtermstats/db.py
+++ b/piholelongtermstats/db.py
@@ -107,6 +107,23 @@ def get_timestamp_range(days, start_date, end_date, timezone):
 
     return start_timestamp, end_timestamp
 
+def load_hostname_mapping(db_path):
+    """Load ip -> (name, nameUpdated) rows from network_addresses table."""
+    conn = connect_to_sql(db_path)
+    try:
+        query = """
+        SELECT ip, name, nameUpdated
+        FROM network_addresses
+        WHERE name IS NOT NULL AND name != ''
+        """
+        df = pd.read_sql_query(query, conn)
+        logging.info(f"Loaded {len(df)} hostname rows from {db_path}")
+    except Exception as e:
+        logging.warning(f"Could not load hostname mapping from {db_path}: {e}")
+        df = pd.DataFrame(columns=["ip", "name", "nameUpdated"])
+    finally:
+        conn.close()
+    return df
 
 def read_pihole_ftl_db(
     db_paths,

--- a/piholelongtermstats/db.py
+++ b/piholelongtermstats/db.py
@@ -107,22 +107,74 @@ def get_timestamp_range(days, start_date, end_date, timezone):
 
     return start_timestamp, end_timestamp
 
-def load_hostname_mapping(db_path):
-    """Load ip -> (name, nameUpdated) rows from network_addresses table."""
-    conn = connect_to_sql(db_path)
+def get_hostname_map_via_mac(conn):
+    """Build ip to hostname and ip to mac dict from PiHole's network tables."""
+    
+    # join the network and network_adressed table
+    query = """
+    SELECT n.hwaddr, n.macVendor, na.ip, na.name AS hostname, na.lastSeen
+    FROM network_addresses na
+    JOIN network n ON n.id = na.network_id
+    """
     try:
-        query = """
-        SELECT ip, name, nameUpdated
-        FROM network_addresses
-        WHERE name IS NOT NULL AND name != ''
-        """
         df = pd.read_sql_query(query, conn)
-        logging.info(f"Loaded {len(df)} hostname rows from {db_path}")
-    except Exception as e:
-        logging.warning(f"Could not load hostname mapping from {db_path}: {e}")
-        df = pd.DataFrame(columns=["ip", "name", "nameUpdated"])
-    finally:
-        conn.close()
+    except (sqlite3.OperationalError, pd.errors.DatabaseError) as e:
+        logging.warning(
+            "Pi-hole network tables not found. Hostname/MAC resolution is unavailable; "
+            "clients will fall back to IP address-based resolution where necessary."
+        )
+        logging.debug(e)
+        return {}, {}
+
+    # remove entries with no hostname
+    has_hostname = df[df["hostname"].notna() & (df["hostname"] != "")]
+    
+    # latest first
+    canonical_names = (
+        has_hostname.sort_values("lastSeen", ascending=False)
+        .drop_duplicates(subset="hwaddr")[["hwaddr", "hostname"]]
+    )
+
+    # latest ip first, remove rows with missing hostnames
+    latest_ip = (
+        df.sort_values("lastSeen", ascending=False)
+        .drop_duplicates(subset=["hwaddr", "ip"])
+        .drop(columns=["hostname"])
+    )
+    # mac,ip, hostname combined
+    merged = latest_ip.merge(canonical_names, on="hwaddr", how="left")
+
+    ip_to_hostname = merged.set_index("ip")["hostname"].to_dict()
+    ip_to_mac = merged.set_index("ip")["hwaddr"].to_dict()
+
+    return ip_to_hostname, ip_to_mac
+
+def resolve_clients(df, hostname_map, mac_map, client_id="hostname"):
+    """
+    Resolve clients based on client-id parameters, default is hostname.
+    """
+
+    df["client_ip"] = df["client"]
+    df["client_mac"] = df["client_ip"].map(mac_map)
+    hostname = df["client_ip"].map(hostname_map)
+
+    if client_id == "ip":
+        resolved = df["client_ip"]
+    elif client_id == "mac":
+        resolved = df["client_mac"].fillna(df["client_ip"])
+    elif client_id == "hostname":
+        resolved = hostname.fillna(df["client_ip"])
+    elif client_id == "hostname_mac":
+        resolved = hostname.fillna(df["client_ip"]) + " (" + df["client_mac"].fillna("unknown-mac") + ")"
+    elif client_id == "hostname_ip":
+        resolved = hostname.where(hostname.isna(), hostname + " (" + df["client_ip"] + ")")
+        resolved = resolved.fillna(df["client_ip"])
+    elif client_id == "mac_ip":
+        resolved = df["client_mac"].fillna("unknown-mac") + " (" + df["client_ip"] + ")"
+    else:
+        raise ValueError(f"Unknown mode: {client_id}")
+
+    df["client"] = resolved
     return df
 
 def read_pihole_ftl_db(
@@ -132,6 +184,7 @@ def read_pihole_ftl_db(
     end_date=None,
     chunksize=None,
     timezone="UTC",
+    client_id="hostname",
 ):
     """Read the PiHole FTL database"""
 
@@ -143,7 +196,6 @@ def read_pihole_ftl_db(
         f"Reading data from PiHole-FTL database(s) for timestamps ranging from {start_timestamp} to {end_timestamp} (TZ: UTC)..."
     )
 
-    # no sql injection
     query = """
     SELECT id, timestamp, type, status, domain, client, reply_time	 
     FROM queries
@@ -156,11 +208,12 @@ def read_pihole_ftl_db(
             f"Processing database {db_idx + 1}/{len(db_paths)} at {db_path}..."
         )
         conn = connect_to_sql(db_path)
-
+        ip_to_hostname, ip_to_mac = get_hostname_map_via_mac(conn)
         try:
             chunk_num = 0
             for chunk in pd.read_sql_query(query, conn, params=params, chunksize=chunksize[db_idx]):
                 chunk_num += 1
+                chunk = resolve_clients(chunk, ip_to_hostname, ip_to_mac, client_id=client_id)
                 logging.info(
                     f"Processing dataframe chunk {chunk_num} from database {db_idx + 1} at {db_path}..."
                 )

--- a/piholelongtermstats/db.py
+++ b/piholelongtermstats/db.py
@@ -9,7 +9,6 @@ import psutil
 import pandas as pd
 import logging
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
-import gc
 
 
 ####### reading the database #######
@@ -59,9 +58,6 @@ def probe_sample_df(conn):
         "ts"
     ].iloc[0]
     oldest_ts = pd.to_datetime(oldest_ts_raw, unit="s", utc=True)
-
-    del sample_df
-    gc.collect()
 
     return chunksize, latest_ts, oldest_ts
 

--- a/piholelongtermstats/plot.py
+++ b/piholelongtermstats/plot.py
@@ -1,5 +1,5 @@
 ## Author :  Davis T. Daniel
-## PiHoleLongTermStats v.0.2.6
+## PiHoleLongTermStats v.0.2.7
 ## License :  MIT
 
 import logging

--- a/piholelongtermstats/process.py
+++ b/piholelongtermstats/process.py
@@ -1,5 +1,5 @@
 ## Author :  Davis T. Daniel
-## PiHoleLongTermStats v.0.2.6
+## PiHoleLongTermStats v.0.2.7
 ## License :  MIT
 
 import re

--- a/piholelongtermstats/process.py
+++ b/piholelongtermstats/process.py
@@ -61,7 +61,9 @@ def preprocess_df(df, timezone="UTC"):
     df["timestamp"] = df["timestamp"].dt.tz_convert(timezone)
     df["date"] = df["timestamp"].dt.normalize()  # needed in group by operations
     df["hour"] = df["timestamp"].dt.hour
-    df["day_period"] = df["hour"].apply(lambda h: "Day" if 6 <= h < 24 else "Night")
+    df["day_period"] = "Night"
+    df.loc[(df["hour"] >= 6) & (df["hour"] <   24), "day_period"] = "Day"
+    #df["day_period"] = df["hour"].apply(lambda h: "Day" if 6 <= h < 24 else "Night")
     logging.info(
         f"Set timestamp, date, hour and day_period columns using timezone : {timezone}"
     )

--- a/piholelongtermstats/stats.py
+++ b/piholelongtermstats/stats.py
@@ -1,5 +1,5 @@
 ## Author :  Davis T. Daniel
-## PiHoleLongTermStats v.0.2.6
+## PiHoleLongTermStats v.0.2.7
 ## License :  MIT
 
 import logging
@@ -83,15 +83,6 @@ def _domain_stats(stats, df):
 
     stats["top_allowed_domain_count"] = int(allowed_domains.max()) if not allowed_domains.empty else 0
     stats["top_blocked_domain_count"] = int(blocked_domains.max()) if not blocked_domains.empty else 0
-    
-    # stats["top_allowed_domain_count"] = (
-    #     len(df[df["domain"] == stats["top_allowed_domain"]]) 
-    #     if stats["top_allowed_domain"] != "N/A" else 0
-    # )
-    # stats["top_blocked_domain_count"] = (
-    #     len(df[df["domain"] == stats["top_blocked_domain"]]) 
-    #     if stats["top_blocked_domain"] != "N/A" else 0
-    # )
     
     allowed_domain_clients = (
         df[
@@ -239,15 +230,6 @@ def _day_night_stats(stats, df):
     stats["day_top_allowed_domain_count"] = int(day_allowed_domains.max()) if not day_allowed_domains.empty else 0
     stats["day_top_blocked_domain_count"] = int(day_blocked_domains.max()) if not day_blocked_domains.empty else 0
     
-    # stats["day_top_allowed_domain_count"] = (
-    #     len(day_df[day_df["domain"] == stats["day_top_allowed_domain"]])
-    #     if stats["day_top_allowed_domain"] != "N/A" else 0
-    # )
-    # stats["day_top_blocked_domain_count"] = (
-    #     len(day_df[day_df["domain"] == stats["day_top_blocked_domain"]])
-    #     if stats["day_top_blocked_domain"] != "N/A" else 0
-    # )
-    
     day_allowed_domain_clients = (
         day_df[
             (day_df["status_type"] == "Allowed")
@@ -290,15 +272,6 @@ def _day_night_stats(stats, df):
 
     stats["night_top_allowed_domain_count"] = int(night_allowed_domains.max()) if not night_allowed_domains.empty else 0
     stats["night_top_blocked_domain_count"] = int(night_blocked_domains.max()) if not night_blocked_domains.empty else 0
-    
-    # stats["night_top_allowed_domain_count"] = (
-    #     len(night_df[night_df["domain"] == stats["night_top_allowed_domain"]])
-    #     if stats["night_top_allowed_domain"] != "N/A" else 0
-    # )
-    # stats["night_top_blocked_domain_count"] = (
-    #     len(night_df[night_df["domain"] == stats["night_top_blocked_domain"]])
-    #     if stats["night_top_blocked_domain"] != "N/A" else 0
-    # )
     
     night_allowed_domain_clients = (
         night_df[
@@ -410,21 +383,6 @@ def _idle_time_stats(stats, df_sorted):
     else:
         before_gap = None
         after_gap = None
-
-
-    # if max_idle_idx is not None and max_idle_idx > 0:
-    #     before_gap = (
-    #         df_sorted.loc[max_idle_idx - 1, "timestamp"].strftime("%d-%b %Y %H:%M:%S.%f")[:-4]
-    #     )
-    # else:
-    #     before_gap = None
-    
-    # if max_idle_idx is not None:
-    #     after_gap = df_sorted.loc[max_idle_idx, "timestamp"].strftime(
-    #         "%d-%b %Y %H:%M:%S.%f"
-    #     )[:-4]
-    # else:
-    #     after_gap = None
 
     stats["max_idle_s"] = max_idle_s
     stats["avg_time_between_blocked"] = avg_time_between_blocked

--- a/piholelongtermstats/stats.py
+++ b/piholelongtermstats/stats.py
@@ -80,15 +80,18 @@ def _domain_stats(stats, df):
     
     stats["top_allowed_domain"] = allowed_domains.idxmax() if not allowed_domains.empty else "N/A"
     stats["top_blocked_domain"] = blocked_domains.idxmax() if not blocked_domains.empty else "N/A"
+
+    stats["top_allowed_domain_count"] = int(allowed_domains.max()) if not allowed_domains.empty else 0
+    stats["top_blocked_domain_count"] = int(blocked_domains.max()) if not blocked_domains.empty else 0
     
-    stats["top_allowed_domain_count"] = (
-        len(df[df["domain"] == stats["top_allowed_domain"]]) 
-        if stats["top_allowed_domain"] != "N/A" else 0
-    )
-    stats["top_blocked_domain_count"] = (
-        len(df[df["domain"] == stats["top_blocked_domain"]]) 
-        if stats["top_blocked_domain"] != "N/A" else 0
-    )
+    # stats["top_allowed_domain_count"] = (
+    #     len(df[df["domain"] == stats["top_allowed_domain"]]) 
+    #     if stats["top_allowed_domain"] != "N/A" else 0
+    # )
+    # stats["top_blocked_domain_count"] = (
+    #     len(df[df["domain"] == stats["top_blocked_domain"]]) 
+    #     if stats["top_blocked_domain"] != "N/A" else 0
+    # )
     
     allowed_domain_clients = (
         df[
@@ -232,15 +235,18 @@ def _day_night_stats(stats, df):
     
     day_blocked_domains = day_df[day_df["status_type"] == "Blocked"]["domain"].value_counts()
     stats["day_top_blocked_domain"] = day_blocked_domains.idxmax() if not day_blocked_domains.empty else "N/A"
+
+    stats["day_top_allowed_domain_count"] = int(day_allowed_domains.max()) if not day_allowed_domains.empty else 0
+    stats["day_top_blocked_domain_count"] = int(day_blocked_domains.max()) if not day_blocked_domains.empty else 0
     
-    stats["day_top_allowed_domain_count"] = (
-        len(day_df[day_df["domain"] == stats["day_top_allowed_domain"]])
-        if stats["day_top_allowed_domain"] != "N/A" else 0
-    )
-    stats["day_top_blocked_domain_count"] = (
-        len(day_df[day_df["domain"] == stats["day_top_blocked_domain"]])
-        if stats["day_top_blocked_domain"] != "N/A" else 0
-    )
+    # stats["day_top_allowed_domain_count"] = (
+    #     len(day_df[day_df["domain"] == stats["day_top_allowed_domain"]])
+    #     if stats["day_top_allowed_domain"] != "N/A" else 0
+    # )
+    # stats["day_top_blocked_domain_count"] = (
+    #     len(day_df[day_df["domain"] == stats["day_top_blocked_domain"]])
+    #     if stats["day_top_blocked_domain"] != "N/A" else 0
+    # )
     
     day_allowed_domain_clients = (
         day_df[
@@ -281,15 +287,18 @@ def _day_night_stats(stats, df):
     
     night_blocked_domains = night_df[night_df["status_type"] == "Blocked"]["domain"].value_counts()
     stats["night_top_blocked_domain"] = night_blocked_domains.idxmax() if not night_blocked_domains.empty else "N/A"
+
+    stats["night_top_allowed_domain_count"] = int(night_allowed_domains.max()) if not night_allowed_domains.empty else 0
+    stats["night_top_blocked_domain_count"] = int(night_blocked_domains.max()) if not night_blocked_domains.empty else 0
     
-    stats["night_top_allowed_domain_count"] = (
-        len(night_df[night_df["domain"] == stats["night_top_allowed_domain"]])
-        if stats["night_top_allowed_domain"] != "N/A" else 0
-    )
-    stats["night_top_blocked_domain_count"] = (
-        len(night_df[night_df["domain"] == stats["night_top_blocked_domain"]])
-        if stats["night_top_blocked_domain"] != "N/A" else 0
-    )
+    # stats["night_top_allowed_domain_count"] = (
+    #     len(night_df[night_df["domain"] == stats["night_top_allowed_domain"]])
+    #     if stats["night_top_allowed_domain"] != "N/A" else 0
+    # )
+    # stats["night_top_blocked_domain_count"] = (
+    #     len(night_df[night_df["domain"] == stats["night_top_blocked_domain"]])
+    #     if stats["night_top_blocked_domain"] != "N/A" else 0
+    # )
     
     night_allowed_domain_clients = (
         night_df[
@@ -373,10 +382,10 @@ def _idle_time_stats(stats, df_sorted):
     idle_gaps = df_sorted["idle_gap"].dropna()
     
     if not idle_gaps.empty:
-        max_idle_ms = idle_gaps.max()
+        max_idle_s = idle_gaps.max() # idle_gaps comes from dt.total_seconds
         max_idle_idx = idle_gaps.idxmax()
     else:
-        max_idle_ms = None
+        max_idle_s = None
         max_idle_idx = None
 
     blocked = df_sorted[df_sorted["status_type"] == "Blocked"]
@@ -401,7 +410,7 @@ def _idle_time_stats(stats, df_sorted):
     else:
         after_gap = None
 
-    stats["max_idle_ms"] = max_idle_ms
+    stats["max_idle_s"] = max_idle_s
     stats["avg_time_between_blocked"] = avg_time_between_blocked
     stats["avg_time_between_allowed"] = avg_time_between_allowed
     stats["before_gap"] = before_gap

--- a/piholelongtermstats/stats.py
+++ b/piholelongtermstats/stats.py
@@ -14,10 +14,10 @@ def _main_heading_stats(stats, df, min_date_available, max_date_available):
     stats["n_data_points"] = len(df)
     logging.info(f"Stats will be based on {stats['n_data_points']} data points.")
 
-    stats["oldest_data_point"] = f"{min_date_available.strftime('%-d-%-m-%Y (%H:%M)')}"
-    stats["latest_data_point"] = f"{max_date_available.strftime('%-d-%-m-%Y (%H:%M)')}"
-    stats["min_date"] = df["timestamp"].min().strftime("%-d-%-m-%Y (%H:%M)")
-    stats["max_date"] = df["timestamp"].max().strftime("%-d-%-m-%Y (%H:%M)")
+    stats["oldest_data_point"] = min_date_available.strftime("%d-%m-%Y (%H:%M)")
+    stats["latest_data_point"] = max_date_available.strftime("%d-%m-%Y (%H:%M)")
+    stats["min_date"] = df["timestamp"].min().strftime("%d-%m-%Y (%H:%M)")
+    stats["max_date"] = df["timestamp"].max().strftime("%d-%m-%Y (%H:%M)")
     logging.info(
         f"Stats will be computed for dates ranging from {stats['min_date']} to {stats['max_date']}"
     )

--- a/piholelongtermstats/stats.py
+++ b/piholelongtermstats/stats.py
@@ -396,19 +396,35 @@ def _idle_time_stats(stats, df_sorted):
     allowed_times = allowed["timestamp"].diff().dt.total_seconds().dropna()
     avg_time_between_allowed = allowed_times.mean() if not allowed_times.empty else None
 
-    if max_idle_idx is not None and max_idle_idx > 0:
-        before_gap = (
-            df_sorted.loc[max_idle_idx - 1, "timestamp"].strftime("%d-%b %Y %H:%M:%S.%f")[:-4]
-        )
+    if max_idle_idx is not None:
+        pos = df_sorted.index.get_loc(max_idle_idx)
+
+        if pos > 0:
+            before_gap_dt = df_sorted.iloc[pos - 1]["timestamp"]
+            before_gap = before_gap_dt.strftime("%d-%b %Y %H:%M:%S.%f")[:-4]
+        else:
+            before_gap = None
+
+        after_gap_dt = df_sorted.iloc[pos]["timestamp"]
+        after_gap = after_gap_dt.strftime("%d-%b %Y %H:%M:%S.%f")[:-4]
     else:
         before_gap = None
-    
-    if max_idle_idx is not None:
-        after_gap = df_sorted.loc[max_idle_idx, "timestamp"].strftime(
-            "%d-%b %Y %H:%M:%S.%f"
-        )[:-4]
-    else:
         after_gap = None
+
+
+    # if max_idle_idx is not None and max_idle_idx > 0:
+    #     before_gap = (
+    #         df_sorted.loc[max_idle_idx - 1, "timestamp"].strftime("%d-%b %Y %H:%M:%S.%f")[:-4]
+    #     )
+    # else:
+    #     before_gap = None
+    
+    # if max_idle_idx is not None:
+    #     after_gap = df_sorted.loc[max_idle_idx, "timestamp"].strftime(
+    #         "%d-%b %Y %H:%M:%S.%f"
+    #     )[:-4]
+    # else:
+    #     after_gap = None
 
     stats["max_idle_s"] = max_idle_s
     stats["avg_time_between_blocked"] = avg_time_between_blocked
@@ -417,9 +433,6 @@ def _idle_time_stats(stats, df_sorted):
     stats["after_gap"] = after_gap
 
     logging.info("Computed data for time stats.")
-
-    del allowed, blocked
-    gc.collect()
 
     return stats
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,6 +159,39 @@ def dummy_db_date_range(temp_dir):
     yield str(db_path), df
 
 
+@pytest.fixture(scope="session")
+def dummy_db_with_network(temp_dir):
+    """Create a test database with queries and network tables populated."""
+    df = create_dummy_dataframe(seed=1, n_rows=100)
+    db_path = Path(temp_dir) / "test_ftl_network.db"
+    
+    conn = sqlite3.connect(str(db_path))
+    df.to_sql("queries", conn, index=False, if_exists="replace")
+    
+    network_data = pd.DataFrame({
+        "id": [1, 2],
+        "hwaddr": ["aa:bb:cc:dd:ee:11", "aa:bb:cc:dd:ee:22"],
+        "macVendor": ["Vendor1", "Vendor2"]
+    })
+    network_data.to_sql("network", conn, index=False, if_exists="replace")
+    
+    unique_clients = df["client"].unique()
+    ip1 = unique_clients[0] if len(unique_clients) > 0 else "192.168.1.2"
+    ip2 = unique_clients[1] if len(unique_clients) > 1 else "192.168.1.3"
+    
+    network_addresses_data = pd.DataFrame({
+        "network_id": [1, 2],
+        "ip": [ip1, ip2],
+        "name": ["client-one.local", "client-two.local"],
+        "lastSeen": [1700000000, 1700000100]
+    })
+    network_addresses_data.to_sql("network_addresses", conn, index=False, if_exists="replace")
+    
+    conn.close()
+    yield str(db_path), df, {ip1: "client-one.local", ip2: "client-two.local"}, {ip1: "aa:bb:cc:dd:ee:11", ip2: "aa:bb:cc:dd:ee:22"}
+
+
+
 @pytest.fixture
 def sample_dataframe():
     """Create a small sample DataFrame for quick tests."""

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -88,8 +88,11 @@ class TestProbeSampleDf:
     def test_probe_sample_df_empty_database(self, dummy_db_empty):
         """Test probe_sample_df with empty database."""
         conn = connect_to_sql(dummy_db_empty)
-        with pytest.raises(ValueError):
-            chunksize, latest_ts, oldest_ts = probe_sample_df(conn)
+        try:
+            with pytest.raises(ValueError):
+                probe_sample_df(conn)
+        finally:
+            conn.close()
 
 class TestGetTimestampRange:
     """Tests for get_timestamp_range function."""

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -205,7 +205,8 @@ class TestReadPiholeFtlDb:
         df_result = pd.concat(chunks)
         
         # check columns
-        assert set(df_result.columns) == set(df_expected_mod.columns)
+        expected_cols = set(df_expected_mod.columns) | {"client_ip", "client_mac"}
+        assert set(df_result.columns) == expected_cols
         
         assert len(df_result) > 0
 
@@ -233,7 +234,8 @@ class TestReadPiholeFtlDb:
         df_result = pd.concat(chunks)
         
         assert len(df_result) > 0
-        assert set(df_result.columns) == set(df1_mod.columns)
+        expected_cols = set(df1_mod.columns) | {"client_ip", "client_mac"}
+        assert set(df_result.columns) == expected_cols
 
     def test_read_pihole_ftl_db_with_date_range(self, dummy_db_date_range):
         """Test reading with specific date range."""
@@ -295,21 +297,6 @@ class TestReadPiholeFtlDb:
         else:
             assert True
 
-    def test_read_pihole_ftl_db_chunksize_none(self, dummy_db_single):
-        """Test reading with chunksize=None."""
-        db_path, _ = dummy_db_single
-        
-        chunks = list(read_pihole_ftl_db(
-            db_paths=[db_path],
-            chunksize=[None],
-            start_date=None,
-            end_date=None,
-            days=31,
-            timezone="UTC",
-        ))
-        
-        assert isinstance(chunks, list)
-
     def test_read_pihole_ftl_db_timezone_conversion(self, dummy_db_single):
         """Test that timezone parameter affects date range calculation."""
         db_path, _ = dummy_db_single
@@ -360,3 +347,52 @@ class TestReadPiholeFtlDb:
         
         assert hasattr(result, "__iter__")
         assert not hasattr(result, "__len__") 
+
+    def test_resolve_clients_modes(self, dummy_db_with_network):
+        """Test resolve_clients with various client_id formatting modes."""
+        _, df, hostname_map, mac_map = dummy_db_with_network
+        from piholelongtermstats.db import resolve_clients
+        
+        # client_id="ip"
+        df_test = df.copy()
+        res = resolve_clients(df_test.copy(), hostname_map, mac_map, client_id="ip")
+        assert (res["client"] == df_test["client"]).all()
+        
+        # client_id="mac"
+        res = resolve_clients(df_test.copy(), hostname_map, mac_map, client_id="mac")
+        for ip, mac in mac_map.items():
+            mask = df_test["client"] == ip
+            if mask.any():
+                assert (res.loc[mask, "client"] == mac).all()
+                
+        # client_id="hostname"
+        res = resolve_clients(df_test.copy(), hostname_map, mac_map, client_id="hostname")
+        for ip, hostname in hostname_map.items():
+            mask = df_test["client"] == ip
+            if mask.any():
+                assert (res.loc[mask, "client"] == hostname).all()
+
+    def test_read_pihole_ftl_db_with_network_integration(self, dummy_db_with_network):
+        """Test read_pihole_ftl_db resolves client names using network tables."""
+        db_path, _, hostname_map, _ = dummy_db_with_network
+        
+        conn = connect_to_sql(db_path)
+        chunksize, _, _ = probe_sample_df(conn)
+        conn.close()
+        
+        chunks = list(read_pihole_ftl_db(
+            db_paths=[db_path],
+            chunksize=[chunksize],
+            start_date=None,
+            end_date=None,
+            days=31,
+            timezone="UTC",
+            client_id="hostname",
+        ))
+        
+        df_result = pd.concat(chunks)
+        for ip, hostname in hostname_map.items():
+            mask = df_result["client_ip"] == ip
+            if mask.any():
+                assert (df_result.loc[mask, "client"] == hostname).all()
+

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -243,14 +243,14 @@ class TestComputeStats:
         stats = compute_stats(stats_dataframe, min_date, max_date)
         
         # Check idle time stats exist
-        assert "max_idle_ms" in stats
+        assert "max_idle_s" in stats
         assert "avg_time_between_blocked" in stats
         assert "avg_time_between_allowed" in stats
         assert "before_gap" in stats
         assert "after_gap" in stats
         
         # Check max_idle_ms is positive
-        assert stats["max_idle_ms"] >= 0
+        assert stats["max_idle_s"] >= 0
 
     def test_compute_stats_unique_stats(self, stats_dataframe):
         """Test unique stats."""


### PR DESCRIPTION
* Added a new CLI option and configuration mapping (`PIHOLE_LT_STATS_CLIENT_ID`) to select how clients are resolved, grouped, and displayed on the dashboard.
* Integrates directly with Pi-hole's network tables (`network` and `network_addresses`) to resolve IP addresses to hostnames and MAC addresses, falls back to IP.
* Corrected the calculation of top allowed/blocked domains to ensure that domain counts are only counted for the matching status